### PR TITLE
Use --force for bump-formula-pr

### DIFF
--- a/.ci/update_formula_version.sh
+++ b/.ci/update_formula_version.sh
@@ -43,7 +43,7 @@ update_formula() {
   version="$2"
   # TODO: download URL as variable
   info "update_formula: updating the formula '${formula}' to '${version}'."
-  brew bump-formula-pr --dry-run --write \
+  brew bump-formula-pr --dry-run --write --force \
     --url "https://downloads.yugabyte.com/yugabyte-${version}-darwin.tar.gz" \
     "${formula}"
   modified_files="${modified_files} ${formula}"

--- a/.github/workflows/update-formula-version.yaml
+++ b/.github/workflows/update-formula-version.yaml
@@ -36,7 +36,6 @@ jobs:
         .ci/update_formula_version.sh '${{steps.extract-version.outputs.yb_version}}'
     - name: "Run brew audit on changed formula files"
       id: run-audit
-      continue-on-error: true
       run: |
         for file in ${{steps.update-yb-formula.outputs.modified_files}}; do
           if [[ "${file}" =~ .*\/Formula\/yugabytedb(@[0-9]+\.[0-9]+)?\.rb ]]; then
@@ -44,7 +43,6 @@ jobs:
           fi
         done
     - name: "Push the changes"
-      if: steps.run-audit.outcome == 'success'
       run: |
         git status
         git diff
@@ -52,7 +50,7 @@ jobs:
         git commit -m "Update the version to ${{steps.extract-version.outputs.yb_version}}"
         git push origin ${{ github.ref }}
     - name: "Push the changes to a branch"
-      if: steps.run-audit.outcome == 'failure'
+      if: failure() && steps.run-audit.outcome == 'failure'
       run: |
         git status
         git diff

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Update formula version](https://github.com/yugabyte/homebrew-yugabytedb/workflows/Update%20formula%20version/badge.svg)](https://github.com/yugabyte/homebrew-yugabytedb/actions?query=workflow%3A%22Update+formula+version%22)
+
 <img src="https://github.com/yugabyte/yugabyte-db/raw/master/architecture/images/ybDB_horizontal.jpg" width="256"/> <img src="https://brew.sh/assets/img/homebrew-256x256.png" height="72">
 
 # The Yugabyte DB Homebrew Tap


### PR DESCRIPTION
- Ref: https://github.com/yugabyte/homebrew-yugabytedb/runs/875462845?check_suite_focus=true#step:5:18
- Use failure() function instead of continue-on-error, this marks the
  audit steps as failed and still runs the last step which pushes the
  changes to an alternative branch.
- Add status badge to README.md