### PR TITLE
updated depends_on for Java to use OpenJDK (:java was failing)

### DIFF
--- a/Formula/yugabytedb-client.rb
+++ b/Formula/yugabytedb-client.rb
@@ -4,7 +4,7 @@ class YugabytedbClient < Formula
   url "https://downloads.yugabyte.com/yugabyte-client-2.1.1.0-darwin.tar.gz"
   sha256 "102a85f1ad9e02df46edeae0d2ef126aefd2b594e8a335284facf94d812dc8c3"
 
-  depends_on "openjdk"
+  depends_on "openjdk@8"
   depends_on "python"
 
   def install

--- a/Formula/yugabytedb-client.rb
+++ b/Formula/yugabytedb-client.rb
@@ -4,7 +4,7 @@ class YugabytedbClient < Formula
   url "https://downloads.yugabyte.com/yugabyte-client-2.1.1.0-darwin.tar.gz"
   sha256 "102a85f1ad9e02df46edeae0d2ef126aefd2b594e8a335284facf94d812dc8c3"
 
-  depends_on :java => "1.8"
+  depends_on "openjdk"
   depends_on "python"
 
   def install

--- a/Formula/yugabytedb.rb
+++ b/Formula/yugabytedb.rb
@@ -4,7 +4,7 @@ class Yugabytedb < Formula
   url "https://downloads.yugabyte.com/yugabyte-2.1.8.2-darwin.tar.gz"
   sha256 "dd6cbd63ad4dd150c9707ed5dc8f3696adf9828dff941bae2255bc04eff7e924"
 
-  depends_on "openjdk"
+  depends_on "openjdk@8"
   depends_on "python"
 
   def install

--- a/Formula/yugabytedb.rb
+++ b/Formula/yugabytedb.rb
@@ -4,7 +4,7 @@ class Yugabytedb < Formula
   url "https://downloads.yugabyte.com/yugabyte-2.1.8.2-darwin.tar.gz"
   sha256 "dd6cbd63ad4dd150c9707ed5dc8f3696adf9828dff941bae2255bc04eff7e924"
 
-  depends_on :java => "1.8"
+  depends_on "openjdk"
   depends_on "python"
 
   def install


### PR DESCRIPTION
Running `brew tap yugabyte/yugabytedb` fails. I updated the `depends_on :java` dependiencies in your Homebrew tap to `depends_on "openjdk"`, as the `depends_on :java` dependencies are no longer valid.

**Terminal Output before PR**
```
==> Tapping yugabyte/yugabytedb
Cloning into '/usr/local/Homebrew/Library/Taps/yugabyte/homebrew-yugabytedb'...
remote: Enumerating objects: 151, done.
remote: Counting objects: 100% (43/43), done.
remote: Compressing objects: 100% (32/32), done.
remote: Total 151 (delta 12), reused 35 (delta 9), pack-reused 108
Receiving objects: 100% (151/151), 36.17 KiB | 1.21 MiB/s, done.
Resolving deltas: 100% (38/38), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/yugabyte/homebrew-yugabytedb/Formula/yugabytedb.rb
yugabytedb: Unsupported special dependency :java
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/yugabyte/homebrew-yugabytedb/Formula/yugabytedb-client.rb
yugabytedb-client: Unsupported special dependency :java
Error: Cannot tap yugabyte/yugabytedb: invalid syntax in tap!
```
